### PR TITLE
Allow importing errors for existing tasks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# System files
+.project
+.DS_Store
+.sass-cache
+node_modules
+.tmp
+
+# Local
+.resources


### PR DESCRIPTION
The /csv endpoint was modified to allow the import of errors for
existing tasks. The only existing validation is done on the csv's
hashed key.
